### PR TITLE
Update reference URL in foundry-module schema

### DIFF
--- a/V11/foundry-module.schema.json
+++ b/V11/foundry-module.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "./foundry-base-package.schema.json"
+      "$ref": "https://raw.githubusercontent.com/AceKokuren/foundry-schemas/main/V11/foundry-base-package.schema.json"
     }
   ],
   "properties": {


### PR DESCRIPTION
Changed the "$ref" value in foundry-module.schema.json. The relative path to the foundry-base-package.schema.json was replaced with an absolute URL. This ensures that the correct version of the base package schema is accessed regardless of the project's structure.